### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,23 @@
+{
+  "name": "jquery.idle",
+  "main": "jquery.idle.js",
+  "version": "1.2.1",
+  "homepage": "https://github.com/kidh0/jquery.idle",
+  "authors": [
+    "Henrique Boaventura <hboaventura@gmail.com>"
+  ],
+  "description": "A dead simple jQuery plugin that executes a callback function if the user is idle.",
+  "keywords": [
+    "jquery",
+    "idle",
+    "plugin"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Added a `bower.json` file and added the plugin to the bower registry.

The plugin is now installable via `bower install jquery.idle`.